### PR TITLE
use secrets manager over SSM paramter store env vars

### DIFF
--- a/requests_api/src/main/resources/application.conf
+++ b/requests_api/src/main/resources/application.conf
@@ -3,5 +3,5 @@ http.host="0.0.0.0"
 http.port=9001
 contextURL=${?context_url}
 aws.metrics.namespace=${?metrics_namespace}
-sierra.auth.user=${?sierra_auth_user}
-sierra.auth.pass=${?sierra_auth_pass}
+sierra.api.key=${?sierra_api_key}
+sierra.api.secret=${?sierra_api_secret}

--- a/terraform/stack/services.tf
+++ b/terraform/stack/services.tf
@@ -18,8 +18,8 @@ module "items_api" {
   nlb_port = "${local.items_listener_port}"
 
   secret_env_vars = {
-    sierra_api_key    = "stacks/config/prod/sierra_api_key"
-    sierra_api_secret = "stacks/config/prod/sierra_api_secret"
+    sierra_api_key    = "stacks/prod/sierra_api_key"
+    sierra_api_secret = "stacks/prod/sierra_api_secret"
   }
 
   secret_env_vars_length = "2"
@@ -52,8 +52,8 @@ module "requests_api" {
   nlb_port = "${local.requests_listener_port}"
 
   secret_env_vars = {
-    sierra_api_key    = "stacks/config/prod/sierra_api_key"
-    sierra_api_secret = "stacks/config/prod/sierra_api_secret"
+    sierra_api_key    = "stacks/prod/sierra_api_key"
+    sierra_api_secret = "stacks/prod/sierra_api_secret"
   }
 
   secret_env_vars_length = "2"


### PR DESCRIPTION
I was using the wrong service to store secrets.
Now I am not