### PR TITLE
use header naming conventions

### DIFF
--- a/terraform/modules/resource_integration/auth/main.tf
+++ b/terraform/modules/resource_integration/auth/main.tf
@@ -56,7 +56,7 @@ module "auth_subresource_integration" {
   forward_path = "${var.forward_path}/{proxy}"
 
   request_parameters = {
-    integration.request.path.proxy              = "method.request.path.proxy"
-    integration.request.header.X-SierraPatronId = "context.authorizer.claims.custom:patronId"
+    integration.request.path.proxy                   = "method.request.path.proxy"
+    integration.request.header.Weco-Sierra-Patron-Id = "context.authorizer.claims.custom:patronId"
   }
 }


### PR DESCRIPTION
_⚠️ Naming something alert ⚠️_

Naming the header on these conventions:
https://specs.openstack.org/openstack/api-wg/guidelines/headers.html

They recommend naming it something namespaced. I've used weco.
Happy?