### PR TITLE
Holds can have null pickUpBy dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ make stacks_api-test
 # before running!
 
 # build and publish apps
-make request_api-publish 
-make stacks_api-publish 
+make requests_api-publish 
+make items_api-publish 
 
 # set up release
 ./docker_run.py --aws --root -- -it wellcome/release_tooling:119 prepare

--- a/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksUserHolds.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/models/StacksUserHolds.scala
@@ -37,5 +37,5 @@ case class StacksHoldStatus(
 
 case class StacksPickup(
                          location: StacksLocation,
-                         pickUpBy: Instant
+                         pickUpBy: Option[Instant]
                        )

--- a/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/SierraService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/services/SierraService.scala
@@ -85,9 +85,9 @@ class SierraService(baseUrl: Option[String], username: String, password: String)
         hold.getPickupLocation.getName
       ),
       // This should be a simpler conversion to a Java Instant
-      pickUpBy = Instant.ofEpochSecond(
-        hold.getPickupByDate.toEpochSecond
-      )
+      pickUpBy = Option(hold.getPickupByDate)
+        .map(_.toEpochSecond)
+        .map(Instant.ofEpochSecond)
     )
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/SierraServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/SierraServiceTest.scala
@@ -48,7 +48,7 @@ class SierraServiceTest
                       id = "sepbb",
                       label = "Rare Materials Room"
                     ),
-                    pickUpBy = Instant.parse("2019-12-03T04:00:00Z")
+                    pickUpBy = Some(Instant.parse("2019-12-03T04:00:00Z"))
                   ),
                   status = StacksHoldStatus(
                     id = "i",

--- a/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/StacksServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/services/StacksServiceTest.scala
@@ -100,13 +100,12 @@ class StacksServiceTest
                   ),
                   pickup = StacksPickup(
                     location = StacksLocation("sepbb", "Rare Materials Room"),
-                    pickUpBy = Instant.parse("2019-12-03T04:00:00Z")
+                    pickUpBy = Some(Instant.parse("2019-12-03T04:00:00Z"))
                   ),
                   status = StacksHoldStatus("i", "item hold ready for pickup.")
                 )
               )
             )
-
           }
         }
       }


### PR DESCRIPTION
In order that we handle the situation where a request has been made but a pickup date has not yet been assigned we should deal with the case where a hold has no pickup date.