### PR TITLE
Omit optional fields in request response

### DIFF
--- a/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApi.scala
+++ b/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApi.scala
@@ -8,7 +8,10 @@ import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import grizzled.slf4j.Logging
 import io.circe.Printer
 import uk.ac.wellcome.platform.stacks.common.models.display.DisplayResultsList
-import uk.ac.wellcome.platform.stacks.common.models.{CatalogueItemIdentifier, StacksUserIdentifier}
+import uk.ac.wellcome.platform.stacks.common.models.{
+  CatalogueItemIdentifier,
+  StacksUserIdentifier
+}
 import uk.ac.wellcome.platform.stacks.common.services.StacksService
 import uk.ac.wellcome.platform.stacks.requests.api.models.Request
 

--- a/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApi.scala
+++ b/requests_api/src/main/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApi.scala
@@ -6,11 +6,9 @@ import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Route
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import grizzled.slf4j.Logging
+import io.circe.Printer
 import uk.ac.wellcome.platform.stacks.common.models.display.DisplayResultsList
-import uk.ac.wellcome.platform.stacks.common.models.{
-  CatalogueItemIdentifier,
-  StacksUserIdentifier
-}
+import uk.ac.wellcome.platform.stacks.common.models.{CatalogueItemIdentifier, StacksUserIdentifier}
 import uk.ac.wellcome.platform.stacks.common.services.StacksService
 import uk.ac.wellcome.platform.stacks.requests.api.models.Request
 
@@ -24,6 +22,10 @@ trait RequestsApi extends Logging with FailFastCirceSupport {
 
   implicit val ec: ExecutionContext
   implicit val stacksWorkService: StacksService
+
+  // Omit optional fields in response to clients
+  implicit val printer: Printer =
+    Printer.noSpaces.copy(dropNullValues = true)
 
   val routes: Route = concat(
     pathPrefix("requests") {

--- a/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApiFeatureTest.scala
+++ b/requests_api/src/test/scala/uk/ac/wellcome/platform/stacks/requests/api/RequestsApiFeatureTest.scala
@@ -193,7 +193,6 @@ class RequestsApiFeatureTest
                  |    {
                  |      "item" : {
                  |        "id" : "n5v7b4md",
-                 |        "status" : null,
                  |        "type" : "Item"
                  |      },
                  |      "pickupDate" : "2019-12-03T04:00:00Z",


### PR DESCRIPTION
Makes the API results for items a bit nicer.