### PR TITLE
Get the items API to start and log to Elastic Cloud

### DIFF
--- a/items_api/src/main/resources/logback.xml
+++ b/items_api/src/main/resources/logback.xml
@@ -5,17 +5,15 @@
     </encoder>
   </appender>
 
-  <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
-    <layout class="net.logstash.logback.layout.LogstashLayout">
-      <customFields>
-        {"introspection": {"namespace":"${NAMESPACE:-unset}","service_id":"${SERVICE_ID:-unset}","task_id": "${TASK_ID:-unset}","image_id": "${IMAGE_ID:-unset}"}}
-      </customFields>
-    </layout>
-
-    <host>${logstash_host}</host>
-    <port>514</port>
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>8192</queueSize>
+    <neverBlock>true</neverBlock>
+    <appender-ref ref="STDOUT"/>
   </appender>
 
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="ASYNC"/>
+  </root>
 
   <root level="${log_level:-INFO}">
     <appender-ref ref="STDOUT"/>

--- a/requests_api/src/main/resources/logback.xml
+++ b/requests_api/src/main/resources/logback.xml
@@ -5,16 +5,15 @@
     </encoder>
   </appender>
 
-  <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashUdpSocketAppender">
-    <layout class="net.logstash.logback.layout.LogstashLayout">
-      <customFields>
-        {"introspection": {"namespace":"${NAMESPACE:-unset}","service_id":"${SERVICE_ID:-unset}","task_id": "${TASK_ID:-unset}","image_id": "${IMAGE_ID:-unset}"}}
-      </customFields>
-    </layout>
-
-    <host>${logstash_host}</host>
-    <port>514</port>
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>8192</queueSize>
+    <neverBlock>true</neverBlock>
+    <appender-ref ref="STDOUT"/>
   </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="ASYNC"/>
+  </root>
 
   <root level="${log_level:-INFO}">
     <appender-ref ref="STDOUT"/>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,6 +21,8 @@ module "prod_stack" {
   # but we can remove it when we delete all the Cognito infra.
   cognito_user_pool_arn = "arn:aws:cognito-idp:eu-west-1:760097843905:userpool/eu-west-1_oToO0mWFj"
 
+  elastic_cloud_vpce_sg_id = local.elastic_cloud_vpce_sg_id
+
   auth_scopes = []
 
   static_content_bucket_name = module.infra.static_content_bucket_name

--- a/terraform/modules/service/main.tf
+++ b/terraform/modules/service/main.tf
@@ -50,6 +50,12 @@ module "log_router_container" {
   use_privatelink_endpoint = true
 }
 
+module "log_router_container_secrets_permissions" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.4.0"
+  secrets   = module.log_router_container.shared_secrets_logging
+  role_name = module.task_definition.task_execution_role_name
+}
+
 module "app_container" {
   source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.4.0"
   name   = "app"

--- a/terraform/stack/locals.tf
+++ b/terraform/stack/locals.tf
@@ -5,6 +5,7 @@ locals {
   api_security_groups = [
     aws_security_group.service_egress_security_group.id,
     aws_security_group.service_lb_ingress_security_group.id,
+    var.elastic_cloud_vpce_sg_id,
   ]
 
   context_url = "https://api.wellcomecollection.org/stacks/v1/context.json"

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -18,6 +18,10 @@ variable "private_subnets" {
   type = list(string)
 }
 
+variable "elastic_cloud_vpce_sg_id" {
+  type = string
+}
+
 variable "static_content_bucket_name" {}
 
 variable "release_label" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -12,3 +12,19 @@ terraform {
     region         = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "infra_critical" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/shared.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+locals {
+  elastic_cloud_vpce_sg_id = data.terraform_remote_state.infra_critical.outputs["ec_catalogue_privatelink_sg_id"]
+}


### PR DESCRIPTION
The commit messages hopefully explain what I’m doing here – trying to get the items API working for https://github.com/wellcomecollection/stacks-service/issues/93

This PR is just about getting the task to *start*. There's more work to get it to register with the load balancer, be visible behind API Gateway, add authentication, etc – we can do those later.

You can see the logs from the started task in Kibana: [https://logging.wellcomecollection.org/&lt;snipped query&gt;](https://logging.wellcomecollection.org/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-04-15T06:00:00.000Z',to:now))&_a=(columns:!(service_name,log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'94746ad0-81c5-11eb-b41a-c9fd641654c0',key:ecs_cluster,negate:!f,params:(query:stacks-api),type:phrase),query:(match_phrase:(ecs_cluster:stacks-api)))),index:'94746ad0-81c5-11eb-b41a-c9fd641654c0',interval:auto,query:(language:kuery,query:''),sort:!()))

Hopefully the individual commit messages explain the different steps I've taken. 

Closes https://github.com/wellcomecollection/platform/issues/4297