### PR TITLE
Cache the Sierra access tokens between invocations

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/AkkaClient.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/AkkaClient.scala
@@ -5,7 +5,11 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling.{Marshal, Marshaller}
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
+import akka.http.scaladsl.model.headers.{
+  Authorization,
+  BasicHttpCredentials,
+  OAuth2BearerToken
+}
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 
 import java.time.Instant
@@ -103,7 +107,7 @@ trait AkkaClientPost extends AkkaClient {
 }
 
 trait AkkaClientTokenExchange
-  extends AkkaClientPost
+    extends AkkaClientPost
     with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
 
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
@@ -129,7 +133,9 @@ trait AkkaClientTokenExchange
       result <- response match {
         case SuccessResponse(Some(AccessToken(access_token, expires_in))) =>
           Future.successful(
-            (OAuth2BearerToken(access_token), Instant.now().plusSeconds(expires_in))
+            (
+              OAuth2BearerToken(access_token),
+              Instant.now().plusSeconds(expires_in))
           )
         case _ =>
           Future.failed(

--- a/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/AkkaClient.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/AkkaClient.scala
@@ -105,7 +105,7 @@ trait AkkaClientPost extends AkkaClient {
       }
 }
 
-trait AkkaClientTokenExchange extends AkkaClientPost {
+trait AkkaClientTokenExchange extends AkkaClientPost with TokenExchange {
 
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import io.circe.generic.auto._
@@ -114,7 +114,7 @@ trait AkkaClientTokenExchange extends AkkaClientPost {
 
   val tokenPath: Path
 
-  protected def getToken(
+  protected def getNewToken(
     credentials: BasicHttpCredentials
   ): Future[OAuth2BearerToken] = {
     for {

--- a/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchange.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchange.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, OAuth2BearerToken}
+
+import java.time.Instant
+import scala.concurrent.Future
+
+trait TokenExchange {
+  private val cachedToken: Option[OAuth2BearerToken] = None
+  private val cachedTokenExpiryTime: Option[Instant] = None
+
+  println(cachedToken)
+  println(cachedTokenExpiryTime)
+
+  protected def getNewToken(credentials: BasicHttpCredentials): Future[OAuth2BearerToken]
+
+  protected def getToken(
+    credentials: BasicHttpCredentials
+  ): Future[OAuth2BearerToken] =
+    getNewToken(credentials)
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchange.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchange.scala
@@ -16,13 +16,17 @@ trait TokenExchange[C, T] {
 
   def getToken(credentials: C): Future[T] =
     cachedToken match {
-      case Some((token, expiryTime)) if expiryTime.minusSeconds(expiryGracePeriod).isAfter(Instant.now()) =>
+      case Some((token, expiryTime))
+          if expiryTime
+            .minusSeconds(expiryGracePeriod)
+            .isAfter(Instant.now()) =>
         Future.successful(token)
 
       case _ =>
-        getNewToken(credentials).map { case (token, expiryTime) =>
-          cachedToken = Some((token, expiryTime))
-          token
+        getNewToken(credentials).map {
+          case (token, expiryTime) =>
+            cachedToken = Some((token, expiryTime))
+            token
         }
     }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchangeTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchangeTest.scala
@@ -15,11 +15,13 @@ class TokenExchangeTest extends AnyFunSpec with Matchers with ScalaFutures {
 
   class MemoryTokenExchange(
     tokens: Seq[(Credentials, Instant)]
-  )(implicit val ec: ExecutionContext) extends TokenExchange[Credentials, Token] {
+  )(implicit val ec: ExecutionContext)
+      extends TokenExchange[Credentials, Token] {
     var calls = 0
     override protected val expiryGracePeriod = 0
 
-    override protected def getNewToken(credentials: Credentials): Future[(Token, Instant)] =
+    override protected def getNewToken(
+      credentials: Credentials): Future[(Token, Instant)] =
       synchronized {
         val index = calls
         calls += 1

--- a/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchangeTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/stacks/common/http/TokenExchangeTest.scala
@@ -1,0 +1,88 @@
+package uk.ac.wellcome.platform.stacks.common.http
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class TokenExchangeTest extends AnyFunSpec with Matchers with ScalaFutures {
+  type Credentials = String
+  type Token = String
+
+  class MemoryTokenExchange(
+    tokens: Seq[(Credentials, Instant)]
+  )(implicit val ec: ExecutionContext) extends TokenExchange[Credentials, Token] {
+    var calls = 0
+    override protected val expiryGracePeriod = 0
+
+    override protected def getNewToken(credentials: Credentials): Future[(Token, Instant)] =
+      synchronized {
+        val index = calls
+        calls += 1
+
+        Future.fromTry(Try(tokens(index)))
+      }
+  }
+
+  val credentials = "password"
+
+  val now = Instant.now()
+
+  it("retrieves a token") {
+    val exchange = new MemoryTokenExchange(
+      tokens = Seq(
+        ("token1", now)
+      )
+    )
+
+    whenReady(exchange.getToken(credentials)) {
+      _ shouldBe "token1"
+    }
+  }
+
+  it("caches a token, and doesn't fetch it again until it expires") {
+    val exchange = new MemoryTokenExchange(
+      tokens = Seq(
+        ("token1", now.plusSeconds(1)),
+        ("token2", now)
+      )
+    )
+
+    // Get the token three times, verify we get the same token each time,
+    // but that the underlying method was only called once.
+    whenReady(exchange.getToken(credentials)) { resp1 =>
+      resp1 shouldBe "token1"
+
+      whenReady(exchange.getToken(credentials)) { resp2 =>
+        resp2 shouldBe "token1"
+
+        whenReady(exchange.getToken(credentials)) { resp3 =>
+          resp3 shouldBe "token1"
+        }
+      }
+    }
+
+    exchange.calls shouldBe 1
+
+    // Now wait for the existing token to expire, and check we can fetch the new token
+    Thread.sleep(1500)
+
+    whenReady(exchange.getToken(credentials)) {
+      _ shouldBe "token2"
+    }
+
+    exchange.calls shouldBe 2
+  }
+
+  it("fails if there is no cached token and the underlying lookup fails") {
+    val brokenExchange = new MemoryTokenExchange(tokens = Seq.empty)
+
+    whenReady(brokenExchange.getToken(credentials).failed) {
+      _ shouldBe a[IndexOutOfBoundsException]
+    }
+  }
+}


### PR DESCRIPTION
Currently the items API will fetch a new Sierra access token for every request. That puts three network requests on the critical path:

1. Go out to the Sierra auth API for an access token
2. Fetch the associated works from the catalogue API
3. Query the Sierra items API for availability

Sierra access tokens are good for an hour, so let's cache the token rather than fetching it each time. This reduces the risk of us DDOS'ing the Sierra auth server, and should make our API snappier.

Anecdotally, testing locally you see the expected behaviour. Before this patch, making a bunch of requests in quick succession gave me request times which were broadly uniform. Now, the first request is slow, then the subsequent requests are much faster.